### PR TITLE
fixing memory leaks

### DIFF
--- a/ViperMCFSwift/Modules/FisrtModule/Router/FisrtModuleRouter.swift
+++ b/ViperMCFSwift/Modules/FisrtModule/Router/FisrtModuleRouter.swift
@@ -24,7 +24,7 @@ final class FisrtModuleRouter: FisrtModuleRouterInput {
 	}()
 	
 	// MARK: Public
-	var transitionHandler: TransitionHandler!
+	weak var transitionHandler: TransitionHandler!
 	
 	// MARK: -
 	// MARK: FisrtModuleRouterInput


### PR DESCRIPTION
`Router` должен держать слабую ссылку на `ViewController` в переменной `transitionHandler`.